### PR TITLE
Add conffiles to MaintainerScripts

### DIFF
--- a/deb/constants.go
+++ b/deb/constants.go
@@ -160,7 +160,7 @@ var (
 	//DistDirDefault is the default directory for built artifacts
 	DistDirDefault = outDirDefault
 
-	MaintainerScripts = []string{"postinst", "postrm", "prerm", "preinst"}
+	MaintainerScripts = []string{"conffiles", "postinst", "postrm", "prerm", "preinst"}
 
 	//SourceFields are the fields applicable to Source packages
 	//


### PR DESCRIPTION
By adding conffiles to MaintainerScripts we can manually define which files should be treated as configuration and do not overwritten without user interaction.
